### PR TITLE
Added htmx() response macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ Route::get('/', function (HtmxRequest $request)
 
 You can call those methods multiple times if you want to trigger multiple events.
 
+- `response()->htmx(...)`
+
+If you just want to pass the simple HTML response using Laravel view, you can also use the `htmx()` macro response.
+``` php
+Route::get('/', fn () => response()->htmx($viewName, $viewData));
+```
+
+Additionally, this macro can also handle Laravel's built-in validation `$errors` message bag and `old()` input session data:
+``` php
+Route::get('/', fn () => response()->htmx($viewName, $viewData, $validator));
+```
+This can be useful when submitting forms via HTMX and you want to show validation errors within the same response.
+
 ### Render Blade Fragments
 
 This library also provides a basic Blade extension to render [template fragments](https://htmx.org/essays/template-fragments/).

--- a/src/LaravelHtmxServiceProvider.php
+++ b/src/LaravelHtmxServiceProvider.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Mauricius\LaravelHtmx;
 
+use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\ViewErrorBag;
+use Illuminate\Validation\Validator;
 use Mauricius\LaravelHtmx\Http\HtmxRequest;
 use Mauricius\LaravelHtmx\View\BladeFragment;
 
@@ -30,6 +33,19 @@ class LaravelHtmxServiceProvider extends ServiceProvider
         View::macro('renderFragment', function ($view, $fragment, array $data = []) {
             return BladeFragment::render($view, $fragment, $data);
         });
+
+		Response::macro('htmx', function(string $view, array $viewData = [], Validator $validator = null) {
+			if (isset($validator)) {
+				// flash current input for the current runtime request
+				request()->flash();
+				session()->ageFlashData();
+
+				// re-share errors variable with the new validation errors
+				View::share('errors', (new ViewErrorBag)->put('default', $validator->errors()));
+			}
+
+			return view($view, $viewData);
+		});
     }
 
     /**

--- a/tests/HtmxResponseMacroTest.php
+++ b/tests/HtmxResponseMacroTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mauricius\LaravelHtmx\Tests;
+
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ViewErrorBag;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+use RuntimeException;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class HtmxResponseMacroTest extends TestCase
+{
+    use MatchesSnapshots;
+
+    /** @test */
+    public function the_response_should_return_view_content_without_validator()
+    {
+		$label = "htmx";
+		$renderedView = view('simple', [
+			'errors' => new ViewErrorBag,
+			'label' => $label,
+		])->render();
+
+        Route::get('test', fn () => response()->htmx('simple', ['label' => $label]))->middleware([
+			ShareErrorsFromSession::class,
+			StartSession::class,
+		]);
+
+        $response = $this->get('test');
+
+        $response->assertOk();
+
+        $this->assertMatchesSnapshot($renderedView);
+    }
+
+	/** @test */
+    public function the_response_should_return_view_content_with_validator()
+    {
+		$validator = validator([
+			'email' => 'john.doe'
+		], [
+			'email' => 'required|email'
+		]);
+
+		$label = "htmx";
+		$renderedView = view('simple', [
+			'errors' => (new ViewErrorBag)->put('default', $validator->errors()),
+			'label' => $label,
+		])->render();
+
+		Route::get('test', function () use ($label, $validator) {
+			response()->htmx('simple', ['label' => $label], $validator);
+		})->middleware(StartSession::class);
+
+        $response = $this->get('test');
+
+        $response->assertOk();
+
+        $this->assertMatchesSnapshot($renderedView);
+    }
+}

--- a/tests/__snapshots__/HtmxResponseMacroTest__the_response_should_return_view_content_with_validator__1.txt
+++ b/tests/__snapshots__/HtmxResponseMacroTest__the_response_should_return_view_content_with_validator__1.txt
@@ -1,0 +1,5 @@
+<h1>Begin</h1>
+<label>htmx</label>
+<input type="text" name="email" value="">
+	<p>The email field must be a valid email address.</p>
+<h2>End</h2>

--- a/tests/__snapshots__/HtmxResponseMacroTest__the_response_should_return_view_content_without_validator__1.txt
+++ b/tests/__snapshots__/HtmxResponseMacroTest__the_response_should_return_view_content_without_validator__1.txt
@@ -1,0 +1,4 @@
+<h1>Begin</h1>
+<label>htmx</label>
+<input type="text" name="email" value="">
+<h2>End</h2>

--- a/tests/views/simple.blade.php
+++ b/tests/views/simple.blade.php
@@ -1,0 +1,7 @@
+<h1>Begin</h1>
+<label>{{ $label }}</label>
+<input type="text" name="email" value="{{ old('email') }}">
+@error('email')
+	<p>{{ $message }}</p>
+@enderror
+<h2>End</h2>


### PR DESCRIPTION
Hi,

I came up with a simple Response macro, I explained in the README file:

`response()->htmx(...)`

If you just want to pass the simple HTML response using Laravel view, you can also use the `htmx()` macro response.
``` php
Route::get('/', fn () => response()->htmx($viewName, $viewData));
```

Additionally, this macro can also handle Laravel's built-in validation `$errors` message bag and `old()` input session data:
``` php
Route::get('/', fn () => response()->htmx($viewName, $viewData, $validator));
```
This can be useful when submitting forms via HTMX and you want to show validation errors within the same response.