### PR TITLE
isHtmxButNotBoosted() sugar function

### DIFF
--- a/src/Http/HtmxRequest.php
+++ b/src/Http/HtmxRequest.php
@@ -29,6 +29,16 @@ class HtmxRequest extends Request
     }
 
     /**
+     * Indicates that the request is made via Htmx.
+     *
+     * @return bool
+     */
+    public function isHtmxButNotBoosted(): bool
+    {
+        return $this->isHtmxRequest() && !$this->isBoosted();
+    }
+
+    /**
      * The current URL of the browser when the htmx request was made.
      *
      * @return string|null

--- a/src/Http/HtmxRequest.php
+++ b/src/Http/HtmxRequest.php
@@ -29,7 +29,7 @@ class HtmxRequest extends Request
     }
 
     /**
-     * Indicates that the request is made via Htmx.
+     * Indicates that the request is made via Htmx but *not* using hx-boost.
      *
      * @return bool
      */

--- a/tests/Http/HtmxRequestTest.php
+++ b/tests/Http/HtmxRequestTest.php
@@ -35,6 +35,22 @@ class HtmxRequestTest extends TestCase
     }
 
     /** @test */
+    public function a_request_is_not_htmx_unboosted_if_it_is_an_htmx_request_but_a_boosted_one()
+    {
+        $request = $this->makeRequest('GET', '/', [], [], [], ['HTTP_HX-REQUEST' => true, 'HTTP_HX-BOOSTED' => true]);
+
+        $this->assertFalse($request->isHtmxButNotBoosted());
+    }
+
+    /** @test */
+    public function a_request_is_htmx_unboosted_if_it_is_an_htmx_request_but_not_a_boosted_one()
+    {
+        $request = $this->makeRequest('GET', '/', [], [], [], ['HTTP_HX-REQUEST' => true]);
+
+        $this->assertTrue($request->isHtmxButNotBoosted());
+    }
+
+    /** @test */
     public function a_request_should_return_the_current_url_of_the_browser_that_makes_the_request_if_the_hx_current_url_is_set()
     {
         $request = $this->makeRequest('GET', '/', [], [], [], ['HTTP_HX_CURRENT_URL' => 'http://localhost']);


### PR DESCRIPTION
I often find myself having to determine whether an HTMX request is boosted or not, so as to know whether I should return partials or a full page, and it would be nice to not have to check both conditions every time, which is why I made this small sugar helper.