### PR TITLE
Support Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,20 +11,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.0, 8.1, 8.2, 8.3]
-                laravel: [^8.80, 9.*, 10.*, 11.*]
+                php: ['8.1', '8.2', '8.3']
+                laravel: ['9.0', '10.0', '11.0']
                 dependency-version: [prefer-lowest, prefer-stable]
                 exclude:
-                    -   laravel: 11.*
-                        php: 8.0
-                    -   laravel: 11.*
-                        php: 8.1
-                    -   laravel: 10.*
-                        php: 8.0
-                    -   laravel: ^8.80
-                        php: 8.2
-                    -   laravel: ^8.80
-                        php: 8.3
+                    -   laravel: '11.0'
+                        php: '8.1'
 
         runs-on: ubuntu-latest
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
@@ -40,7 +32,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "illuminate/contracts:${{ matrix.laravel }}" --no-update
+                    composer require "illuminate/contracts:^${{ matrix.laravel }}" --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist  --no-progress --no-interaction
 
             -   name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,33 +1,36 @@
 name: run-tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
     test:
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
-                php: [8.0, 8.1, 8.2]
-                laravel: [^8.80, 9.*, 10.*]
+                php: [8.0, 8.1, 8.2, 8.3]
+                laravel: [^8.80, 9.*, 10.*, 11.*]
                 dependency-version: [prefer-lowest, prefer-stable]
-                include:
-                    -   laravel: 10.*
-                        testbench: 8.*
-                    -   laravel: 9.*
-                        testbench: 7.*
-                    -   laravel: ^8.80
-                        testbench: 6.23
                 exclude:
+                    -   laravel: 11.*
+                        php: 8.0
+                    -   laravel: 11.*
+                        php: 8.1
                     -   laravel: 10.*
                         php: 8.0
                     -   laravel: ^8.80
                         php: 8.2
+                    -   laravel: ^8.80
+                        php: 8.3
 
         runs-on: ubuntu-latest
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -37,7 +40,8 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                    composer require "illuminate/contracts:${{ matrix.laravel }}" --no-update
+                    composer update --${{ matrix.dependency-version }} --prefer-dist  --no-progress --no-interaction
+
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "ext-mbstring": "*",
-        "php": "^8.0",
-        "illuminate/contracts": "^8.80|^9.0|^10.0|^11.0"
+        "php": "^8.1",
+        "illuminate/contracts": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.0|^6.0|^7.0|^8.1",
-        "orchestra/testbench": "^6.24|^7.0|^8.0|^9.0",
+        "nunomaduro/collision": "^6.0|^7.0|^8.1",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.5|^10.0",
         "spatie/phpunit-snapshot-assertions": "^4.2|^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "ext-mbstring": "*",
-        "php": "^8.0|^8.1|^8.2",
-        "illuminate/contracts": "^8.80|^9.0|^10.0"
+        "php": "^8.0",
+        "illuminate/contracts": "^8.80|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.0|^6.0|^7.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "nunomaduro/collision": "^5.0|^6.0|^7.0|^8.1",
+        "orchestra/testbench": "^6.24|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.5|^10.0",
-        "spatie/phpunit-snapshot-assertions": "^4.2"
+        "spatie/phpunit-snapshot-assertions": "^4.2|^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds support for Laravel 11

It also updates the workflow by:
- updating `actions/checkout` version
- set `illuminate/contracts` version, which automatically select the proper laravel version (no need to define `orchestra/testbench` version)
- add php 8.3 tests
Also, `^8.0` php version covers all php versions tested