### PR TITLE
Add .stubs.php for IDE support

### DIFF
--- a/.stubs.php
+++ b/.stubs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\View
+{
+    class View
+    {
+        public function renderFragment(string $view, string $fragment, array $data = []): string {}
+    }
+}

--- a/src/LaravelHtmxServiceProvider.php
+++ b/src/LaravelHtmxServiceProvider.php
@@ -23,7 +23,7 @@ class LaravelHtmxServiceProvider extends ServiceProvider
 
         $this->app->bind(HtmxRequest::class, fn ($container) => HtmxRequest::createFrom($container['request']));
 
-        View::macro('renderFragment', function ($view, $fragment, array $data = []) {
+        View::macro('renderFragment', function (string $view, string $fragment, array $data = []) {
             return BladeFragment::render($view, $fragment, $data);
         });
     }


### PR DESCRIPTION
Hey! 👋

This PR adds a `.stubs.php` file that aids IDEs like PHPStorm in understanding the existence of macros:

![image](https://github.com/user-attachments/assets/6ea435c2-9b16-47af-a78e-87783b1c91b3)
